### PR TITLE
Task throws error if dest is not provided in files

### DIFF
--- a/tasks/typescript-formatter.js
+++ b/tasks/typescript-formatter.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
     // Iterate over all specified file groups, async for 'streaming' output on large projects
     grunt.util.async.reduce(this.files, true, function(success, filePair, callback) {
       var files = filePair.src;
-      if (!grunt.file.isDir(filePair.dest)) {
+      if (!options.replace && !grunt.file.isDir(filePair.dest)) {
         grunt.log.error("Destination must be a folder", filePair.dest);
         failed++;
     }


### PR DESCRIPTION
Hi, I am receiving the following error, when I run this grunt task:
`Warning: Arguments to path.join must be strings Use --force to continue.`

The code was expecting a 'dest' property on the files object, but this shouldn't be required if you are using the default option of replace. The pull request checks this condition before validating the dest property.
